### PR TITLE
Disable default features of `curve25519-dalek`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std", "wasm", "embedded"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-curve25519-dalek = { version = "4.1.3", features = ["zeroize"] }
+curve25519-dalek = { version = "4.1.3", default-features = false, features = ["zeroize"] }
 solana-curve25519 = "2.0.13"
 sha2 = "0.10.8"
 


### PR DESCRIPTION
Disable default features of `curve25519-dalek` to prevent the error messages of stack violation from the SBF compiler.