### PR TITLE
adding more versions verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,24 @@ Signature verification roughly follows [RFC 8032](https://datatracker.ietf.org/d
 ## 🚀 Quick Start
 
 ```rust
-use brine_ed25519::sig_verify;
+use brine_ed25519::{sig_verify, sig_verify_prehashed, sig_verifyv};
 
 let pubkey: [u8; 32] = [...];
 let sig: [u8; 64] = [...];
 let message = b"hello world";
 
 sig_verify(&pubkey, &sig, message)?;
+
+let messagev: &[&[u8]] = &[b"hello", b" ", b"world"];
+sig_verifyv(&pubkey, &sig, messagev)?;
+
+let message_hash = &[...];
+sig_verify_prehashed(&pubkey, &sig, message_hash)?;
 ```
 
 Returns `Ok(())` if valid, or `Err(SignatureError)` if the signature is invalid.
+
+`sig_verify_prehashed` verifies signatures over already-hashed bytes. It does not implement RFC 8032 `Ed25519ph`.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
 use core::mem::MaybeUninit;
-use sha2::{ Digest, Sha512 };
 use curve25519_dalek::scalar::Scalar;
+use sha2::{Digest, Sha512};
 use solana_curve25519::{
-    edwards::{subtract_edwards, multiply_edwards, validate_edwards, PodEdwardsPoint},
+    edwards::{multiply_edwards, subtract_edwards, validate_edwards, PodEdwardsPoint},
     scalar::PodScalar,
 };
 
@@ -21,13 +21,57 @@ pub enum SignatureError {
 
 /// Compressed base point
 const G: [u8; 32] = [
-    88, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 
-    102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102
+    88, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+    102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
 ];
 
 /// Verify an ed25519 signature.
+#[inline(always)]
 #[allow(non_snake_case)]
 pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), SignatureError> {
+    sig_verifyv(pubkey, sig, core::slice::from_ref(&message))
+}
+
+/// Verify an ed25519 signature over a vectored message.
+#[inline(always)]
+#[allow(non_snake_case)]
+pub fn sig_verifyv(pubkey: &[u8], sig: &[u8], messagev: &[&[u8]]) -> Result<(), SignatureError> {
+    if pubkey.len() != ED25519_PUBKEY_LEN {
+        return Err(SignatureError::InvalidArgument);
+    }
+
+    if sig.len() != ED25519_SIG_LEN {
+        return Err(SignatureError::InvalidArgument);
+    }
+
+    sig_verify_internal(
+        pubkey.try_into().unwrap(),
+        sig.try_into().unwrap(),
+        messagev,
+    )
+}
+
+/// Verify an ed25519 signature over prehashed bytes.
+///
+/// This does not implement RFC 8032 Ed25519ph. The signer must have signed
+/// `message_hash` directly as the message bytes.
+#[inline(always)]
+#[allow(non_snake_case)]
+pub fn sig_verify_prehashed(
+    pubkey: &[u8],
+    sig: &[u8],
+    message_hash: &[u8],
+) -> Result<(), SignatureError> {
+    sig_verifyv(pubkey, sig, core::slice::from_ref(&message_hash))
+}
+
+#[inline(always)]
+#[allow(non_snake_case)]
+fn sig_verify_internal(
+    pubkey: &[u8; ED25519_PUBKEY_LEN],
+    sig: &[u8; ED25519_SIG_LEN],
+    messagev: &[&[u8]],
+) -> Result<(), SignatureError> {
     // Normally, we could verify the signature using the Solana SDK or
     // dalek_ed25519, but those are too compute, stack, and heap heavy for the
     // SVM.
@@ -36,19 +80,11 @@ pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), Signa
     // of the ed25519 signature verification process.
 
     // Roughly follows the dalek ed25519 crate, but with some changes for the
-    // SVM. Refer to 
+    // SVM. Refer to
     // https://github.com/dalek-cryptography/curve25519-dalek/blob/0964f800ab2114a862543ca000291a6e3531c203/ed25519-dalek/src/verifying.rs#L401
 
-    if pubkey.len() != ED25519_PUBKEY_LEN {
-        return Err(SignatureError::InvalidArgument);
-    }
-
-    if sig.len() != ED25519_SIG_LEN {
-        return Err(SignatureError::InvalidArgument);
-    }
-    
-    let pubkey_point = PodEdwardsPoint(pubkey[..ED25519_PUBKEY_LEN].try_into().unwrap());
-    let (sig_lower, sig_upper) = split_signature(sig.try_into().unwrap());
+    let pubkey_point = PodEdwardsPoint(*pubkey);
+    let (sig_lower, sig_upper) = split_signature(sig);
 
     let sig_R = PodEdwardsPoint(sig_lower);
     let sig_s: Scalar = Option::from(Scalar::from_canonical_bytes(sig_upper))
@@ -59,7 +95,7 @@ pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), Signa
     }
 
     // Note, the point validation below is optional. The internal
-    // PodEdwardsPoint decompress logic is already doing this check. 
+    // PodEdwardsPoint decompress logic is already doing this check.
     // But, this makes it explicit in case the internal logic changes.
 
     // (Remove this check if CU usage is a concern)
@@ -69,13 +105,7 @@ pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), Signa
         return Err(SignatureError::InvalidAccountOwner);
     }
 
-    let mut h: Sha512 = Sha512::new(); // <- Expensive, no system calls available yet.
-    h.update(sig_R.0);
-    h.update(&pubkey);
-    h.update(&message);
-
-    let f = h.finalize();
-    let k = Scalar::from_bytes_mod_order_wide(f.as_ref());
+    let k = challenge_scalar(&sig_R, pubkey, messagev);
 
     let k_bytes = k.to_bytes();
     let pubkey_bytes = pubkey_point.0;
@@ -87,12 +117,10 @@ pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), Signa
 
     // R = sB - kA
 
-    let sB = multiply_edwards(&b, &B)
-        .ok_or(SignatureError::InvalidSignature)?;
+    let sB = multiply_edwards(&b, &B).ok_or(SignatureError::InvalidSignature)?;
     let kA = multiply_edwards(&a, &PodEdwardsPoint(pubkey_bytes))
         .ok_or(SignatureError::InvalidSignature)?;
-    let R = subtract_edwards(&sB, &kA)
-        .ok_or(SignatureError::InvalidSignature)?;
+    let R = subtract_edwards(&sB, &kA).ok_or(SignatureError::InvalidSignature)?;
 
     let expected_R = sig_R.0;
     let computed_R = R.0;
@@ -104,6 +132,23 @@ pub fn sig_verify(pubkey: &[u8], sig: &[u8], message: &[u8]) -> Result<(), Signa
     }
 }
 
+#[inline(always)]
+fn challenge_scalar(
+    sig_r: &PodEdwardsPoint,
+    pubkey: &[u8; ED25519_PUBKEY_LEN],
+    messagev: &[&[u8]],
+) -> Scalar {
+    let mut h: Sha512 = Sha512::new(); // <- Expensive, no system calls available yet.
+    h.update(sig_r.0);
+    h.update(pubkey);
+
+    for message in messagev {
+        h.update(message);
+    }
+
+    let f = h.finalize();
+    Scalar::from_bytes_mod_order_wide(f.as_ref())
+}
 
 /// Split the signature into two 32-byte arrays.
 #[inline(always)]
@@ -114,22 +159,13 @@ fn split_signature(sig: &[u8; 64]) -> ([u8; 32], [u8; 32]) {
     // SAFETY: The length of `sig` is 64 bytes, we're copying 32 bytes into
     // `sig_lower` and `sig_upper` respectively.
     unsafe {
-        core::ptr::copy_nonoverlapping(
-            sig.as_ptr(),
-            sig_lower.as_mut_ptr() as *mut u8,
-            32,
-        );
+        core::ptr::copy_nonoverlapping(sig.as_ptr(), sig_lower.as_mut_ptr() as *mut u8, 32);
 
-        core::ptr::copy_nonoverlapping(
-            sig.as_ptr().add(32),
-            sig_upper.as_mut_ptr() as *mut u8,
-            32,
-        );
+        core::ptr::copy_nonoverlapping(sig.as_ptr().add(32), sig_upper.as_mut_ptr() as *mut u8, 32);
 
         (sig_lower.assume_init(), sig_upper.assume_init())
     }
 }
-
 
 /// Determine if this point is of small order.
 ///
@@ -137,6 +173,7 @@ fn split_signature(sig: &[u8; 64]) -> ([u8; 32], [u8; 32]) {
 ///
 /// * `true` if `self` is in the torsion subgroup \\( \mathcal E[8] \\);
 /// * `false` if `self` is not in the torsion subgroup \\( \mathcal E[8] \\).
+#[inline(always)]
 fn is_small_order(point: &PodEdwardsPoint) -> bool {
     // Create a PodScalar representing the scalar value 8
     let scalar_8 = scalar_from_u64(8);
@@ -152,6 +189,7 @@ fn is_small_order(point: &PodEdwardsPoint) -> bool {
 }
 
 /// Create the identity point (neutral element) in compressed form.
+#[inline(always)]
 fn identity() -> PodEdwardsPoint {
     let mut bytes = [0u8; 32];
     bytes[0] = 1; // The compressed identity point has first byte as 1
@@ -159,12 +197,12 @@ fn identity() -> PodEdwardsPoint {
 }
 
 /// Create a PodScalar from a u64 integer.
+#[inline(always)]
 fn scalar_from_u64(n: u64) -> PodScalar {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&n.to_le_bytes());
     PodScalar(bytes)
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -200,34 +238,55 @@ mod tests {
 
     #[test]
     fn test_hello_world() {
-
-        let pubkey: [u8; 32] = [ 
-            73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 
-            162, 9, 233, 49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166
+        let pubkey: [u8; 32] = [
+            73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
+            49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
         ];
-        let sig: [u8; 64] = [ 
-            164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 
-            105, 33, 58, 86, 28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 
-            35, 102, 183, 203, 111, 33, 55, 170, 180, 138, 92, 196, 185, 201, 122, 167, 
-            15, 112, 9, 228, 226, 112, 111, 10, 142, 73, 85, 43, 81, 152, 204, 13 
+        let sig: [u8; 64] = [
+            164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
+            28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
+            55, 170, 180, 138, 92, 196, 185, 201, 122, 167, 15, 112, 9, 228, 226, 112, 111, 10,
+            142, 73, 85, 43, 81, 152, 204, 13,
         ];
 
         assert!(sig_verify(&pubkey, &sig, "hello world".as_bytes()).is_ok());
         assert!(sig_verify(&pubkey, &sig, "not the right message".as_bytes()).is_err());
     }
 
-   #[test]
-    fn test_vector_1() {
-        let pubkey : [u8; 32] = [
-            0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07, 0x3a,
-            0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68, 0xf7, 0x07, 0x51, 0x1a,
+    #[test]
+    fn test_hello_worldv() {
+        let pubkey: [u8; 32] = [
+            73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
+            49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
+        ];
+        let sig: [u8; 64] = [
+            164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
+            28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
+            55, 170, 180, 138, 92, 196, 185, 201, 122, 167, 15, 112, 9, 228, 226, 112, 111, 10,
+            142, 73, 85, 43, 81, 152, 204, 13,
         ];
 
-        let sig : [u8; 64] = [
-            0xe5, 0x56, 0x43, 0x00, 0xc3, 0x60, 0xac, 0x72, 0x90, 0x86, 0xe2, 0xcc, 0x80, 0x6e, 0x82, 0x8a,
-            0x84, 0x87, 0x7f, 0x1e, 0xb8, 0xe5, 0xd9, 0x74, 0xd8, 0x73, 0xe0, 0x65, 0x22, 0x49, 0x01, 0x55,
-            0x5f, 0xb8, 0x82, 0x15, 0x90, 0xa3, 0x3b, 0xac, 0xc6, 0x1e, 0x39, 0x70, 0x1c, 0xf9, 0xb4, 0x6b,
-            0xd2, 0x5b, 0xf5, 0xf0, 0x59, 0x5b, 0xbe, 0x24, 0x65, 0x51, 0x41, 0x43, 0x8e, 0x7a, 0x10, 0x0b,
+        let messagev: &[&[u8]] = &[b"hello", b" ", b"world"];
+        let bad_messagev: &[&[u8]] = &[b"hello", b" ", b"there"];
+
+        assert!(sig_verifyv(&pubkey, &sig, messagev).is_ok());
+        assert!(sig_verifyv(&pubkey, &sig, bad_messagev).is_err());
+    }
+
+    #[test]
+    fn test_vector_1() {
+        let pubkey: [u8; 32] = [
+            0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64,
+            0x07, 0x3a, 0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68,
+            0xf7, 0x07, 0x51, 0x1a,
+        ];
+
+        let sig: [u8; 64] = [
+            0xe5, 0x56, 0x43, 0x00, 0xc3, 0x60, 0xac, 0x72, 0x90, 0x86, 0xe2, 0xcc, 0x80, 0x6e,
+            0x82, 0x8a, 0x84, 0x87, 0x7f, 0x1e, 0xb8, 0xe5, 0xd9, 0x74, 0xd8, 0x73, 0xe0, 0x65,
+            0x22, 0x49, 0x01, 0x55, 0x5f, 0xb8, 0x82, 0x15, 0x90, 0xa3, 0x3b, 0xac, 0xc6, 0x1e,
+            0x39, 0x70, 0x1c, 0xf9, 0xb4, 0x6b, 0xd2, 0x5b, 0xf5, 0xf0, 0x59, 0x5b, 0xbe, 0x24,
+            0x65, 0x51, 0x41, 0x43, 0x8e, 0x7a, 0x10, 0x0b,
         ];
 
         let message = "".as_bytes();
@@ -238,16 +297,18 @@ mod tests {
 
     #[test]
     fn test_vector_2() {
-        let pubkey : [u8; 32] = [
-            0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7, 0x4d, 0x1b, 0x7e, 0xbc,
-            0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c, 0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c,
+        let pubkey: [u8; 32] = [
+            0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7, 0x4d, 0x1b,
+            0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c, 0xc0, 0xcd, 0x55, 0xf1,
+            0x2a, 0xf4, 0x66, 0x0c,
         ];
 
-        let sig : [u8; 64] = [
-            0x92, 0xa0, 0x09, 0xa9, 0xf0, 0xd4, 0xca, 0xb8, 0x72, 0x0e, 0x82, 0x0b, 0x5f, 0x64, 0x25, 0x40,
-            0xa2, 0xb2, 0x7b, 0x54, 0x16, 0x50, 0x3f, 0x8f, 0xb3, 0x76, 0x22, 0x23, 0xeb, 0xdb, 0x69, 0xda,
-            0x08, 0x5a, 0xc1, 0xe4, 0x3e, 0x15, 0x99, 0x6e, 0x45, 0x8f, 0x36, 0x13, 0xd0, 0xf1, 0x1d, 0x8c,
-            0x38, 0x7b, 0x2e, 0xae, 0xb4, 0x30, 0x2a, 0xee, 0xb0, 0x0d, 0x29, 0x16, 0x12, 0xbb, 0x0c, 0x00,
+        let sig: [u8; 64] = [
+            0x92, 0xa0, 0x09, 0xa9, 0xf0, 0xd4, 0xca, 0xb8, 0x72, 0x0e, 0x82, 0x0b, 0x5f, 0x64,
+            0x25, 0x40, 0xa2, 0xb2, 0x7b, 0x54, 0x16, 0x50, 0x3f, 0x8f, 0xb3, 0x76, 0x22, 0x23,
+            0xeb, 0xdb, 0x69, 0xda, 0x08, 0x5a, 0xc1, 0xe4, 0x3e, 0x15, 0x99, 0x6e, 0x45, 0x8f,
+            0x36, 0x13, 0xd0, 0xf1, 0x1d, 0x8c, 0x38, 0x7b, 0x2e, 0xae, 0xb4, 0x30, 0x2a, 0xee,
+            0xb0, 0x0d, 0x29, 0x16, 0x12, 0xbb, 0x0c, 0x00,
         ];
 
         let message = "r".as_bytes(); // r = 72
@@ -258,17 +319,18 @@ mod tests {
 
     #[test]
     fn test_vector_3() {
-
-        let pubkey : [u8; 32] = [
-            0xfc, 0x51, 0xcd, 0x8e, 0x62, 0x18, 0xa1, 0xa3, 0x8d, 0xa4, 0x7e, 0xd0, 0x02, 0x30, 0xf0, 0x58,
-            0x08, 0x16, 0xed, 0x13, 0xba, 0x33, 0x03, 0xac, 0x5d, 0xeb, 0x91, 0x15, 0x48, 0x90, 0x80, 0x25,
+        let pubkey: [u8; 32] = [
+            0xfc, 0x51, 0xcd, 0x8e, 0x62, 0x18, 0xa1, 0xa3, 0x8d, 0xa4, 0x7e, 0xd0, 0x02, 0x30,
+            0xf0, 0x58, 0x08, 0x16, 0xed, 0x13, 0xba, 0x33, 0x03, 0xac, 0x5d, 0xeb, 0x91, 0x15,
+            0x48, 0x90, 0x80, 0x25,
         ];
 
-        let sig : [u8; 64] = [
-            0x62, 0x91, 0xd6, 0x57, 0xde, 0xec, 0x24, 0x02, 0x48, 0x27, 0xe6, 0x9c, 0x3a, 0xbe, 0x01, 0xa3,
-            0x0c, 0xe5, 0x48, 0xa2, 0x84, 0x74, 0x3a, 0x44, 0x5e, 0x36, 0x80, 0xd7, 0xdb, 0x5a, 0xc3, 0xac,
-            0x18, 0xff, 0x9b, 0x53, 0x8d, 0x16, 0xf2, 0x90, 0xae, 0x67, 0xf7, 0x60, 0x98, 0x4d, 0xc6, 0x59,
-            0x4a, 0x7c, 0x15, 0xe9, 0x71, 0x6e, 0xd2, 0x8d, 0xc0, 0x27, 0xbe, 0xce, 0xea, 0x1e, 0xc4, 0x0a,
+        let sig: [u8; 64] = [
+            0x62, 0x91, 0xd6, 0x57, 0xde, 0xec, 0x24, 0x02, 0x48, 0x27, 0xe6, 0x9c, 0x3a, 0xbe,
+            0x01, 0xa3, 0x0c, 0xe5, 0x48, 0xa2, 0x84, 0x74, 0x3a, 0x44, 0x5e, 0x36, 0x80, 0xd7,
+            0xdb, 0x5a, 0xc3, 0xac, 0x18, 0xff, 0x9b, 0x53, 0x8d, 0x16, 0xf2, 0x90, 0xae, 0x67,
+            0xf7, 0x60, 0x98, 0x4d, 0xc6, 0x59, 0x4a, 0x7c, 0x15, 0xe9, 0x71, 0x6e, 0xd2, 0x8d,
+            0xc0, 0x27, 0xbe, 0xce, 0xea, 0x1e, 0xc4, 0x0a,
         ];
 
         let message = &[0xaf, 0x82];
@@ -277,4 +339,25 @@ mod tests {
         assert!(sig_verify(&pubkey, &sig, "not the right message".as_bytes()).is_err());
     }
 
+    #[test]
+    fn test_sig_verify_prehashed_wrapper() {
+        let pubkey: [u8; 32] = [
+            0xfc, 0x51, 0xcd, 0x8e, 0x62, 0x18, 0xa1, 0xa3, 0x8d, 0xa4, 0x7e, 0xd0, 0x02, 0x30,
+            0xf0, 0x58, 0x08, 0x16, 0xed, 0x13, 0xba, 0x33, 0x03, 0xac, 0x5d, 0xeb, 0x91, 0x15,
+            0x48, 0x90, 0x80, 0x25,
+        ];
+
+        let sig: [u8; 64] = [
+            0x62, 0x91, 0xd6, 0x57, 0xde, 0xec, 0x24, 0x02, 0x48, 0x27, 0xe6, 0x9c, 0x3a, 0xbe,
+            0x01, 0xa3, 0x0c, 0xe5, 0x48, 0xa2, 0x84, 0x74, 0x3a, 0x44, 0x5e, 0x36, 0x80, 0xd7,
+            0xdb, 0x5a, 0xc3, 0xac, 0x18, 0xff, 0x9b, 0x53, 0x8d, 0x16, 0xf2, 0x90, 0xae, 0x67,
+            0xf7, 0x60, 0x98, 0x4d, 0xc6, 0x59, 0x4a, 0x7c, 0x15, 0xe9, 0x71, 0x6e, 0xd2, 0x8d,
+            0xc0, 0x27, 0xbe, 0xce, 0xea, 0x1e, 0xc4, 0x0a,
+        ];
+
+        let digest = &[0xaf, 0x82];
+
+        assert!(sig_verify_prehashed(&pubkey, &sig, digest).is_ok());
+        assert!(sig_verify_prehashed(&pubkey, &sig, "not the right message".as_bytes()).is_err());
+    }
 }


### PR DESCRIPTION
This change adds a new `sig_verifyv` api that accepts `&[&[u8]]`, so callers can verify split message data without building one combined buffer first.

It also reorganizes the verification code so the core logic only exists in one place, which avoids repeating the same implementation across `sig_verify`, `sig_verifyv`, and `sig_verify_prehashed`. The prehashed api is for verifying signatures over already-hashed bytes directly, and is not `RFC 8032 Ed25519` but useful in some cases.

Tests and readme examples were updated to cover the new apis.

@deanmlittle 