### PR TITLE
Reduced dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,24 +17,7 @@ version = "0.2.0"
 dependencies = [
  "curve25519-dalek",
  "sha2",
- "solana-curve25519",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "solana-define-syscall",
 ]
 
 [[package]]
@@ -71,13 +54,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
- "rand_core",
  "rustc_version",
- "serde",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -142,12 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,36 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,20 +144,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "2.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae4261b9a8613d10e77ac831a8fa60b6fa52b9b103df46d641deff9f9812a23"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "solana-define-syscall",
- "subtle",
- "thiserror",
 ]
 
 [[package]]
@@ -241,26 +170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,9 +186,3 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,16 @@ keywords = ["solana", "ed25519", "signature", "no_std", "curve25519"]
 categories = ["cryptography", "no-std", "wasm", "embedded"]
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [dependencies]
 curve25519-dalek = { version = "4.1.3", default-features = false }
-solana-curve25519 = "2.0.13"
 sha2 = { version = "0.10.8", default-features = false }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = "2.3.0"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+priority = 0
+check-cfg = ['cfg(target_os, values("solana"))']

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,0 +1,149 @@
+//! Small curve shim for this crate.
+//!
+//! This crate is mainly meant to run inside Solana. On `target_os = "solana"`,
+//! the point operations used by signature verification go straight to Solana's
+//! native curve syscalls.
+//!
+//! We still support host builds for tests and off-chain callers, so the same
+//! API is backed by `curve25519-dalek` there.
+//!
+//! Keeping that split here avoids pulling in `solana-curve25519` just to wrap a
+//! few point operations. We still use `curve25519-dalek` elsewhere in the crate
+//! for scalar parsing and reduction.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+pub(crate) struct PodScalar(pub [u8; 32]);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+pub(crate) struct PodEdwardsPoint(pub [u8; 32]);
+
+#[cfg(not(target_os = "solana"))]
+mod imp {
+    use super::{PodEdwardsPoint, PodScalar};
+    use curve25519_dalek::{
+        edwards::{CompressedEdwardsY, EdwardsPoint},
+        scalar::Scalar,
+    };
+
+    #[inline(always)]
+    pub(crate) fn validate_edwards(point: &PodEdwardsPoint) -> bool {
+        point_from_pod(point).is_some()
+    }
+
+    #[inline(always)]
+    pub(crate) fn subtract_edwards(
+        left_point: &PodEdwardsPoint,
+        right_point: &PodEdwardsPoint,
+    ) -> Option<PodEdwardsPoint> {
+        let left_point = point_from_pod(left_point)?;
+        let right_point = point_from_pod(right_point)?;
+        let result = &left_point - &right_point;
+        Some(pod_from_point(&result))
+    }
+
+    #[inline(always)]
+    pub(crate) fn multiply_edwards(
+        scalar: &PodScalar,
+        point: &PodEdwardsPoint,
+    ) -> Option<PodEdwardsPoint> {
+        let scalar = scalar_from_pod(scalar)?;
+        let point = point_from_pod(point)?;
+        let result = &scalar * &point;
+        Some(pod_from_point(&result))
+    }
+
+    #[inline(always)]
+    fn point_from_pod(pod: &PodEdwardsPoint) -> Option<EdwardsPoint> {
+        CompressedEdwardsY(pod.0).decompress()
+    }
+
+    #[inline(always)]
+    fn scalar_from_pod(pod: &PodScalar) -> Option<Scalar> {
+        Option::from(Scalar::from_canonical_bytes(pod.0))
+    }
+
+    #[inline(always)]
+    fn pod_from_point(point: &EdwardsPoint) -> PodEdwardsPoint {
+        PodEdwardsPoint(point.compress().to_bytes())
+    }
+}
+
+#[cfg(target_os = "solana")]
+mod imp {
+    use super::{PodEdwardsPoint, PodScalar};
+    use solana_define_syscall::definitions::{
+        sol_curve_group_op,
+        sol_curve_validate_point
+    };
+
+    const CURVE25519_EDWARDS: u64 = 0;
+    const SUB: u64 = 1;
+    const MUL: u64 = 2;
+
+    #[inline(always)]
+    pub(crate) fn validate_edwards(point: &PodEdwardsPoint) -> bool {
+        let mut validate_result = 0u8;
+        let result = unsafe {
+            sol_curve_validate_point(
+                CURVE25519_EDWARDS,
+                point.0.as_ptr(),
+                &mut validate_result
+            )
+        };
+        result == 0
+    }
+
+    #[inline(always)]
+    pub(crate) fn subtract_edwards(
+        left_point: &PodEdwardsPoint,
+        right_point: &PodEdwardsPoint,
+    ) -> Option<PodEdwardsPoint> {
+        let mut result_point = PodEdwardsPoint([0u8; 32]);
+        let result = unsafe {
+            sol_curve_group_op(
+                CURVE25519_EDWARDS,
+                SUB,
+                left_point.0.as_ptr(),
+                right_point.0.as_ptr(),
+                result_point.0.as_mut_ptr(),
+            )
+        };
+
+        if result == 0 {
+            Some(result_point)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn multiply_edwards(
+        scalar: &PodScalar,
+        point: &PodEdwardsPoint,
+    ) -> Option<PodEdwardsPoint> {
+        let mut result_point = PodEdwardsPoint([0u8; 32]);
+        let result = unsafe {
+            sol_curve_group_op(
+                CURVE25519_EDWARDS,
+                MUL,
+                scalar.0.as_ptr(),
+                point.0.as_ptr(),
+                result_point.0.as_mut_ptr(),
+            )
+        };
+
+        if result == 0 {
+            Some(result_point)
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) use imp::{
+    multiply_edwards, 
+    subtract_edwards, 
+    validate_edwards
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 #![no_std]
 
 use core::mem::MaybeUninit;
-use curve25519_dalek::scalar::Scalar;
 use sha2::{Digest, Sha512};
-use solana_curve25519::{
-    edwards::{multiply_edwards, subtract_edwards, validate_edwards, PodEdwardsPoint},
-    scalar::PodScalar,
+use curve25519_dalek::scalar::Scalar;
+
+mod curve;
+use crate::curve::{
+    multiply_edwards, 
+    subtract_edwards, 
+    validate_edwards, 
+    PodEdwardsPoint, 
+    PodScalar,
 };
 
 const ED25519_SIG_LEN: usize = 64;

--- a/test-program/Cargo.lock
+++ b/test-program/Cargo.lock
@@ -388,7 +388,7 @@ version = "0.2.0"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "sha2 0.10.9",
- "solana-curve25519",
+ "solana-define-syscall",
 ]
 
 [[package]]

--- a/test-program/src/lib.rs
+++ b/test-program/src/lib.rs
@@ -60,7 +60,7 @@ fn process_instruction(
         // (e.g. for verifying signatures from off-chain where the message is too large 
         // to fit in a single instruction, or to save compute units by avoiding hashing on-chain)
         // Be careful when doing this
-        MODE_VERIFY_PREHASHED => 
+        MODE_PREHASHED => 
             sig_verify_prehashed(pubkey, sig, payload),
 
         _ => Err(SignatureError::InvalidArgument),
@@ -275,7 +275,7 @@ mod tests {
 
     fn prehashed_ix(digest: &[u8]) -> Instruction {
         instruction(
-            MODE_VERIFY_PREHASHED,
+            MODE_PREHASHED,
             &PREHASHED_PUBKEY,
             &PREHASHED_SIG,
             digest,


### PR DESCRIPTION
This PR tries to remove some of the baggage on both the solana and non-solana build targets. 

Removing `curve25519-dalek` entirely might be possible on the solana target, but it is more involved.