### PR TITLE
Remove SignatureError in favor of ProgramError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,13 @@ dependencies = [
 
 [[package]]
 name = "brine-ed25519"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "rand",
  "sha2",
  "solana-define-syscall",
+ "solana-program-error",
 ]
 
 [[package]]
@@ -202,6 +203,12 @@ name = "solana-define-syscall"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brine-ed25519"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Ed25519 signature verification for Solana SVM programs using curve25519 syscalls"
 license = "MIT"
@@ -14,6 +14,7 @@ crate-type = ["lib"]
 
 [dependencies]
 sha2 = { version = "0.10.8", default-features = false }
+solana-program-error = { version = "3.0.1", default-features = false }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { version = "4.1.3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,23 +14,16 @@ use crate::curve::{
 };
 use crate::hasher::Hasher;
 use crate::scalar::{
-    scalar_from_bytes_mod_order_wide, 
+    scalar_from_bytes_mod_order_wide,
     scalar_from_canonical_bytes
 };
+use solana_program_error::ProgramError;
 
 const ED25519_SIG_LEN:    usize = 64;
 const ED25519_PUBKEY_LEN: usize = 32;
 
 pub type Pubkey    = [u8; ED25519_PUBKEY_LEN];
 pub type Signature = [u8; ED25519_SIG_LEN];
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SignatureError {
-    /// The provided public key is not a valid non-small-order Edwards point.
-    InvalidPublicKey,
-    /// The signature is malformed or does not verify for the provided message.
-    InvalidSignature,
-}
 
 /// Compressed base point
 const G: [u8; 32] = [
@@ -45,7 +38,7 @@ pub fn verify<H: Hasher>(
     pubkey: &Pubkey,
     sig: &Signature,
     messages: &[&[u8]],
-) -> Result<(), SignatureError> {
+) -> Result<(), ProgramError> {
 
     // SAFETY: The length of `sig` is 64 bytes, so slicing the first 32 bytes is always valid.
     let sig_r_bytes: [u8; 32] = sig[..32]
@@ -67,7 +60,7 @@ pub fn verify_prehashed(
     pubkey: &Pubkey,
     sig: &Signature,
     challenge: &[u8; 64],
-) -> Result<(), SignatureError> {
+) -> Result<(), ProgramError> {
     // Normally, we could verify the signature using the Solana SDK or
     // dalek_ed25519, but those are too compute, stack, and heap heavy for the
     // SVM.
@@ -84,7 +77,7 @@ pub fn verify_prehashed(
 
     let sig_R = PodEdwardsPoint(sig_lower);
     let sig_s_bytes =
-        scalar_from_canonical_bytes(sig_upper).ok_or(SignatureError::InvalidSignature)?;
+        scalar_from_canonical_bytes(sig_upper).ok_or(ProgramError::InvalidArgument)?;
 
     validate_pubkey(&pubkey_point)?;
     validate_signature_point(&sig_R)?;
@@ -97,9 +90,9 @@ pub fn verify_prehashed(
 
     // R = sB - kA
 
-    let sB = multiply_edwards(&b, &B).ok_or(SignatureError::InvalidSignature)?;
-    let kA = multiply_edwards(&a, &pubkey_point).ok_or(SignatureError::InvalidPublicKey)?;
-    let R = subtract_edwards(&sB, &kA).ok_or(SignatureError::InvalidSignature)?;
+    let sB = multiply_edwards(&b, &B).ok_or(ProgramError::InvalidArgument)?;
+    let kA = multiply_edwards(&a, &pubkey_point).ok_or(ProgramError::InvalidArgument)?;
+    let R = subtract_edwards(&sB, &kA).ok_or(ProgramError::InvalidArgument)?;
 
     let expected_R = sig_R.0;
     let computed_R = R.0;
@@ -107,25 +100,25 @@ pub fn verify_prehashed(
     if expected_R == computed_R {
         Ok(())
     } else {
-        Err(SignatureError::InvalidSignature)
+        Err(ProgramError::InvalidArgument)
     }
 }
 
 #[inline(always)]
-fn validate_pubkey(pubkey: &PodEdwardsPoint) -> Result<(), SignatureError> {
+fn validate_pubkey(pubkey: &PodEdwardsPoint) -> Result<(), ProgramError> {
     // Keep the explicit curve check even though decompression in the curve shim
     // already performs it. This preserves a stable error mapping for callers.
     if !validate_edwards(pubkey) || is_small_order(pubkey) {
-        Err(SignatureError::InvalidPublicKey)
+        Err(ProgramError::InvalidArgument)
     } else {
         Ok(())
     }
 }
 
 #[inline(always)]
-fn validate_signature_point(sig_r: &PodEdwardsPoint) -> Result<(), SignatureError> {
+fn validate_signature_point(sig_r: &PodEdwardsPoint) -> Result<(), ProgramError> {
     if !validate_edwards(sig_r) || is_small_order(sig_r) {
-        Err(SignatureError::InvalidSignature)
+        Err(ProgramError::InvalidArgument)
     } else {
         Ok(())
     }
@@ -248,7 +241,7 @@ mod tests {
 
         assert_eq!(
             verify::<Sha512>(&pubkey, &sig, &[b"hello world"]),
-            Err(SignatureError::InvalidPublicKey)
+            Err(ProgramError::InvalidArgument)
         );
     }
 
@@ -267,7 +260,7 @@ mod tests {
 
         assert_eq!(
             verify::<Sha512>(&pubkey, &sig, &[b"not the right message"]),
-            Err(SignatureError::InvalidSignature)
+            Err(ProgramError::InvalidArgument)
         );
     }
 

--- a/test-program/Cargo.lock
+++ b/test-program/Cargo.lock
@@ -498,11 +498,12 @@ dependencies = [
 
 [[package]]
 name = "brine-ed25519"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "sha2 0.10.9",
  "solana-define-syscall 2.3.0",
+ "solana-program-error",
 ]
 
 [[package]]

--- a/test-program/src/lib.rs
+++ b/test-program/src/lib.rs
@@ -3,7 +3,6 @@
 
 use brine_ed25519::{verify, hasher::Sha512};
 use pinocchio::{
-    error::ProgramError, 
     default_allocator, nostd_panic_handler, program_entrypoint, 
     AccountView, Address, ProgramResult,
 };
@@ -30,7 +29,6 @@ fn process_instruction(
     _instruction_data: &[u8],
 ) -> ProgramResult {
     verify::<Sha512>(&HELLO_WORLD_PUBKEY, &HELLO_WORLD_SIG, &[b"hello world"])
-        .map_err(|_| ProgramError::Custom(1))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Removing SignatureError to improve devex. The custom error type added extra complexity since every caller had to .map_err it into a ProgramError. Adding solana-program-error to return ProgramError directly

Before:

```
verify::<Sha512>(&pubkey, &sig, &[b"hello world"])
    .map_err(|_| ProgramError::Custom(1))?;
```

After:

```
verify::<Sha512>(&pubkey, &sig, &[b"hello world"])?;
```

Version bump for the API change.
