### PR TITLE
msm + 32-bit barrett reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "curve25519-dalek",
  "rand",
  "sha2",
- "solana-define-syscall",
+ "solana-address",
  "solana-program-error",
 ]
 
@@ -199,10 +199,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-define-syscall"
-version = "2.3.0"
+name = "solana-address"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
+checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 
 [[package]]
 name = "solana-program-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,11 @@ crate-type = ["lib"]
 
 [dependencies]
 sha2 = { version = "0.10.8", default-features = false }
+solana-address = { version = "2.6.0", default-features = false }
 solana-program-error = { version = "3.0.1", default-features = false }
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
+[target.'cfg(all(not(target_arch = "bpf"), not(target_os = "solana")))'.dependencies]
 curve25519-dalek = { version = "4.1.3", default-features = false }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = "2.3.0"
 
 [dev-dependencies]
 curve25519-dalek = { version = "4.1.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A fast, low-overhead, Ed25519 signature verification library for the Solana SVM.
 
 | Operation         | CU (Approx.) |
 |-------------------|--------------|
-| `verify`          |      ~19,114 |
+| `verify`          |      ~12,953 |
 
 This value is measured inside the Solana SVM via `test-program/` and depends on the message size.
 
@@ -60,7 +60,9 @@ Custom hash implementations are supported via the `Hasher` trait.
 
 **A:** Solana does provide a [Ed25519 pre-compile](https://github.com/solana-labs/solana/blob/master/sdk/src/ed25519_instruction.rs) program for signature verification—but it comes with several downsides:
 
+- Costs **more CUs** than the multiscalar multiplication syscall
 - Charges an extra **5000 lamports per signature**
+- Consumes additional transaction data
 - Requires the `instruction_sysvar` to be passed into your program
 - Only verifies signatures on data hardcoded into the transaction
 - Cannot be used with dynamically generated data inside your program

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,149 +1,73 @@
 //! Small curve shim for this crate.
 //!
-//! This crate is mainly meant to run inside Solana. On `target_os = "solana"`,
-//! the point operations used by signature verification go straight to Solana's
-//! native curve syscalls.
+//! This crate is mainly meant to run inside Solana. On `target_arch = "bpf"` or 
+//! `target_os = "solana"`, the point operations used by signature verification 
+//! go straight to Solana's native curve syscalls.
 //!
 //! We still support host builds for tests and off-chain callers, so the same
 //! API is backed by `curve25519-dalek` there.
-//!
-//! Keeping that split here avoids pulling in `solana-curve25519` just to wrap a
-//! few point operations. We still use `curve25519-dalek` elsewhere in the crate
-//! for scalar parsing and reduction.
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(transparent)]
-pub(crate) struct PodScalar(pub [u8; 32]);
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(transparent)]
-pub(crate) struct PodEdwardsPoint(pub [u8; 32]);
-
-#[cfg(not(target_os = "solana"))]
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
 mod imp {
-    use super::{PodEdwardsPoint, PodScalar};
     use curve25519_dalek::{
         edwards::{CompressedEdwardsY, EdwardsPoint},
         scalar::Scalar,
+        traits::Identity,
     };
 
     #[inline(always)]
-    pub(crate) fn validate_edwards(point: &PodEdwardsPoint) -> bool {
-        point_from_pod(point).is_some()
-    }
-
-    #[inline(always)]
-    pub(crate) fn subtract_edwards(
-        left_point: &PodEdwardsPoint,
-        right_point: &PodEdwardsPoint,
-    ) -> Option<PodEdwardsPoint> {
-        let left_point = point_from_pod(left_point)?;
-        let right_point = point_from_pod(right_point)?;
-        let result = &left_point - &right_point;
-        Some(pod_from_point(&result))
-    }
-
-    #[inline(always)]
-    pub(crate) fn multiply_edwards(
-        scalar: &PodScalar,
-        point: &PodEdwardsPoint,
-    ) -> Option<PodEdwardsPoint> {
-        let scalar = scalar_from_pod(scalar)?;
-        let point = point_from_pod(point)?;
-        let result = &scalar * &point;
-        Some(pod_from_point(&result))
-    }
-
-    #[inline(always)]
-    fn point_from_pod(pod: &PodEdwardsPoint) -> Option<EdwardsPoint> {
-        CompressedEdwardsY(pod.0).decompress()
-    }
-
-    #[inline(always)]
-    fn scalar_from_pod(pod: &PodScalar) -> Option<Scalar> {
-        Option::from(Scalar::from_canonical_bytes(pod.0))
-    }
-
-    #[inline(always)]
-    fn pod_from_point(point: &EdwardsPoint) -> PodEdwardsPoint {
-        PodEdwardsPoint(point.compress().to_bytes())
+    pub(crate) fn multiscalar_multiply_edwards(
+        scalars: &[[u8; 32]],
+        points: &[[u8; 32]],
+    ) -> Option<[u8; 32]> {
+        let mut acc = EdwardsPoint::identity();
+        for (s, p) in scalars.iter().zip(points.iter()) {
+            let scalar = Option::from(Scalar::from_canonical_bytes(*s))?;
+            let point = CompressedEdwardsY(*p).decompress()?;
+            acc = &acc + &(&scalar * &point);
+        }
+        Some(acc.compress().to_bytes())
     }
 }
 
-#[cfg(target_os = "solana")]
+#[cfg(any(target_arch = "bpf", target_os = "solana"))]
 mod imp {
-    use super::{PodEdwardsPoint, PodScalar};
-    use solana_define_syscall::definitions::{
-        sol_curve_group_op,
-        sol_curve_validate_point
-    };
-
     const CURVE25519_EDWARDS: u64 = 0;
-    const SUB: u64 = 1;
-    const MUL: u64 = 2;
 
-    #[inline(always)]
-    pub(crate) fn validate_edwards(point: &PodEdwardsPoint) -> bool {
-        let mut validate_result = 0u8;
-        let result = unsafe {
-            sol_curve_validate_point(
-                CURVE25519_EDWARDS,
-                point.0.as_ptr(),
-                &mut validate_result
-            )
-        };
-        result == 0
+    extern "C" {
+        fn sol_curve_multiscalar_mul(
+            curve_id: u64,
+            scalars_addr: *const u8,
+            points_addr: *const u8,
+            points_len: u64,
+            result_point_addr: *mut u8,
+        ) -> u64;
     }
 
     #[inline(always)]
-    pub(crate) fn subtract_edwards(
-        left_point: &PodEdwardsPoint,
-        right_point: &PodEdwardsPoint,
-    ) -> Option<PodEdwardsPoint> {
-        let mut result_point = PodEdwardsPoint([0u8; 32]);
+    pub(crate) fn multiscalar_multiply_edwards(
+        scalars: &[[u8; 32]],
+        points: &[[u8; 32]],
+    ) -> Option<[u8; 32]> {
+        // SAFETY: on success (result == 0) the syscall writes all 32 bytes
+        // of the output point, so the MaybeUninit is fully initialised.
+        let mut result_point = core::mem::MaybeUninit::<[u8; 32]>::uninit();
         let result = unsafe {
-            sol_curve_group_op(
+            sol_curve_multiscalar_mul(
                 CURVE25519_EDWARDS,
-                SUB,
-                left_point.0.as_ptr(),
-                right_point.0.as_ptr(),
-                result_point.0.as_mut_ptr(),
+                scalars.as_ptr() as *const u8,
+                points.as_ptr() as *const u8,
+                points.len() as u64,
+                result_point.as_mut_ptr() as *mut u8,
             )
         };
 
         if result == 0 {
-            Some(result_point)
-        } else {
-            None
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) fn multiply_edwards(
-        scalar: &PodScalar,
-        point: &PodEdwardsPoint,
-    ) -> Option<PodEdwardsPoint> {
-        let mut result_point = PodEdwardsPoint([0u8; 32]);
-        let result = unsafe {
-            sol_curve_group_op(
-                CURVE25519_EDWARDS,
-                MUL,
-                scalar.0.as_ptr(),
-                point.0.as_ptr(),
-                result_point.0.as_mut_ptr(),
-            )
-        };
-
-        if result == 0 {
-            Some(result_point)
+            Some(unsafe { result_point.assume_init() })
         } else {
             None
         }
     }
 }
 
-pub(crate) use imp::{
-    multiply_edwards, 
-    subtract_edwards, 
-    validate_edwards
-};
+pub(crate) use imp::multiscalar_multiply_edwards;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,52 +1,37 @@
 #![no_std]
-use core::mem::MaybeUninit;
 
 pub mod hasher;
 mod curve;
 mod scalar;
 
-use crate::curve::{
-    multiply_edwards,
-    subtract_edwards,
-    validate_edwards,
-    PodEdwardsPoint,
-    PodScalar,
-};
+use crate::curve::multiscalar_multiply_edwards;
 use crate::hasher::Hasher;
-use crate::scalar::{
-    scalar_from_bytes_mod_order_wide,
-    scalar_from_canonical_bytes
-};
+use crate::scalar::scalar_from_bytes_mod_order_wide;
+pub use solana_address::Address;
 use solana_program_error::ProgramError;
 
-const ED25519_SIG_LEN:    usize = 64;
-const ED25519_PUBKEY_LEN: usize = 32;
+pub type Signature = [u8; 64];
 
-pub type Pubkey    = [u8; ED25519_PUBKEY_LEN];
-pub type Signature = [u8; ED25519_SIG_LEN];
-
-/// Compressed base point
-const G: [u8; 32] = [
+/// Negated compressed base point (-G). Identical to G with the sign bit
+/// (bit 7 of the last byte) flipped. Used so that the signature check
+/// `R == sB - kA` can be rewritten as a single multiscalar multiplication:
+/// `msm([s, k], [-G, A]) == -R`.
+const NEG_G: [u8; 32] = [
     88, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
-    102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+    102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 230,
 ];
 
 /// Verify an ed25519 signature over a vectored message using the provided
 /// hash implementation.
 #[inline(always)]
 pub fn verify<H: Hasher>(
-    pubkey: &Pubkey,
+    pubkey: &Address,
     sig: &Signature,
     messages: &[&[u8]],
 ) -> Result<(), ProgramError> {
-
-    // SAFETY: The length of `sig` is 64 bytes, so slicing the first 32 bytes is always valid.
-    let sig_r_bytes: [u8; 32] = sig[..32]
-        .try_into()
-        .unwrap();
-
-    let sig_r = PodEdwardsPoint(sig_r_bytes);
-    let challenge = challenge::<H>(&sig_r, pubkey, messages);
+    // SAFETY: first 32 bytes of [u8; 64] is a valid [u8; 32].
+    let sig_r: &[u8; 32] = unsafe { &*(sig.as_ptr() as *const [u8; 32]) };
+    let challenge = challenge::<H>(sig_r, pubkey, messages);
 
     verify_prehashed(pubkey, sig, &challenge)
 }
@@ -54,85 +39,68 @@ pub fn verify<H: Hasher>(
 /// Verify an ed25519 signature using a precomputed challenge hash `H(R || A || M)`.
 /// This is useful in cases where the challenge hash needs to be computed off-chain
 /// or pre-computed on-chain for efficiency reasons.
+///
+/// # Safety (validation delegated to the MSM syscall)
+///
+/// The following checks are intentionally omitted because the Solana
+/// `sol_curve_multiscalar_mul` syscall already performs them internally
+/// (see `agave/curves/curve25519/src/edwards.rs` and `scalar.rs`):
+///
+/// - **Point decompression / on-curve check** for both `pubkey` and the
+///   constant `-G`: the syscall calls `CompressedEdwardsY::decompress()`
+///   on every point and returns failure if decompression fails.
+/// - **Scalar canonicality** of `s` (the upper half of the signature):
+///   the syscall calls `Scalar::from_canonical_bytes()` on every scalar
+///   and returns failure if the scalar is non-canonical.
+///
+/// If any of those checks fail the MSM returns `None`, which we map to
+/// `ProgramError::InvalidArgument`.
+///
+/// **Small-order rejection** is *not* performed by the MSM syscall.
+/// This matches the behavior of the Ed25519 precompile, which does not
+/// reject small-order public keys or R values either.
 #[inline(always)]
 #[allow(non_snake_case)]
 pub fn verify_prehashed(
-    pubkey: &Pubkey,
+    pubkey: &Address,
     sig: &Signature,
     challenge: &[u8; 64],
 ) -> Result<(), ProgramError> {
-    // Normally, we could verify the signature using the Solana SDK or
-    // dalek_ed25519, but those are too compute, stack, and heap heavy for the
-    // SVM.
-
-    // Refer to https://datatracker.ietf.org/doc/html/rfc8032 for rough outline
-    // of the ed25519 signature verification process.
-
-    // Roughly follows the dalek ed25519 crate, but with some changes for the
-    // SVM. Refer to
-    // https://github.com/dalek-cryptography/curve25519-dalek/blob/0964f800ab2114a862543ca000291a6e3531c203/ed25519-dalek/src/verifying.rs#L401
-
-    let pubkey_point = PodEdwardsPoint(*pubkey);
-    let (sig_lower, sig_upper) = split_signature(sig);
-
-    let sig_R = PodEdwardsPoint(sig_lower);
-    let sig_s_bytes =
-        scalar_from_canonical_bytes(sig_upper).ok_or(ProgramError::InvalidArgument)?;
-
-    validate_pubkey(&pubkey_point)?;
-    validate_signature_point(&sig_R)?;
+    // Split signature into R (first 32 bytes) and s (last 32 bytes).
+    // SAFETY: [u8; 64] has the same layout as [[u8; 32]; 2].
+    let (sig_r, sig_s): &([u8; 32], [u8; 32]) = unsafe { &*(sig as *const [u8; 64] as *const _) };
 
     let k_bytes = scalar_from_bytes_mod_order_wide(challenge);
 
-    let a = PodScalar(k_bytes);
-    let b = PodScalar(sig_s_bytes);
-    let B = PodEdwardsPoint(G);
+    let scalars = [*sig_s, k_bytes];
+    // SAFETY: Address is #[repr(transparent)] over [u8; 32].
+    let pubkey_bytes: &[u8; 32] = unsafe { &*(pubkey as *const Address as *const [u8; 32]) };
+    let points = [NEG_G, *pubkey_bytes];
 
-    // R = sB - kA
+    // msm([s, k], [-G, A]) = s*(-G) + k*A = k*A - s*G = -(s*G - k*A) = -R
+    let neg_R = multiscalar_multiply_edwards(&scalars, &points)
+        .ok_or(ProgramError::InvalidArgument)?;
 
-    let sB = multiply_edwards(&b, &B).ok_or(ProgramError::InvalidArgument)?;
-    let kA = multiply_edwards(&a, &pubkey_point).ok_or(ProgramError::InvalidArgument)?;
-    let R = subtract_edwards(&sB, &kA).ok_or(ProgramError::InvalidArgument)?;
+    // Negate sig_R (flip sign bit) to compare against -R.
+    let mut neg_sig_R = *sig_r;
+    neg_sig_R[31] ^= 0x80;
 
-    let expected_R = sig_R.0;
-    let computed_R = R.0;
-
-    if expected_R == computed_R {
+    if neg_R == neg_sig_R {
         Ok(())
     } else {
         Err(ProgramError::InvalidArgument)
-    }
-}
-
-#[inline(always)]
-fn validate_pubkey(pubkey: &PodEdwardsPoint) -> Result<(), ProgramError> {
-    // Keep the explicit curve check even though decompression in the curve shim
-    // already performs it. This preserves a stable error mapping for callers.
-    if !validate_edwards(pubkey) || is_small_order(pubkey) {
-        Err(ProgramError::InvalidArgument)
-    } else {
-        Ok(())
-    }
-}
-
-#[inline(always)]
-fn validate_signature_point(sig_r: &PodEdwardsPoint) -> Result<(), ProgramError> {
-    if !validate_edwards(sig_r) || is_small_order(sig_r) {
-        Err(ProgramError::InvalidArgument)
-    } else {
-        Ok(())
     }
 }
 
 #[inline(always)]
 fn challenge<H: Hasher>(
-    sig_r: &PodEdwardsPoint,
-    pubkey: &Pubkey,
+    sig_r: &[u8; 32],
+    pubkey: &Address,
     messagev: &[&[u8]],
 ) -> [u8; 64] {
     let mut hasher = H::new();
-    hasher.update(&sig_r.0);
-    hasher.update(pubkey);
+    hasher.update(sig_r);
+    hasher.update(pubkey.as_ref());
 
     for message in messagev {
         hasher.update(message);
@@ -141,26 +109,13 @@ fn challenge<H: Hasher>(
     hasher.finalize()
 }
 
-/// Split the signature into two 32-byte arrays.
-#[inline(always)]
-fn split_signature(sig: &[u8; 64]) -> ([u8; 32], [u8; 32]) {
-    let mut sig_lower: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
-    let mut sig_upper: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
+#[cfg(test)]
+const G: [u8; 32] = [
+    88, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+    102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102, 102,
+];
 
-    // SAFETY: The length of `sig` is 64 bytes, we're copying 32 bytes into
-    // `sig_lower` and `sig_upper` respectively.
-    unsafe {
-        core::ptr::copy_nonoverlapping(sig.as_ptr(), sig_lower.as_mut_ptr() as *mut u8, 32);
-
-        core::ptr::copy_nonoverlapping(sig.as_ptr().add(32), sig_upper.as_mut_ptr() as *mut u8, 32);
-
-        (sig_lower.assume_init(), sig_upper.assume_init())
-    }
-}
-
-/// The eight small-order (torsion) points on Curve25519, in compressed
-/// Edwards form. Any point matching one of these is rejected during
-/// signature verification.
+#[cfg(test)]
 const EIGHT_TORSION: [[u8; 32]; 8] = [
     [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
     [0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b, 0x76, 0x0d, 0x10, 0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39, 0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77, 0x92, 0xac, 0x03, 0x7a],
@@ -172,11 +127,9 @@ const EIGHT_TORSION: [[u8; 32]; 8] = [
     [0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b, 0x76, 0x0d, 0x10, 0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39, 0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77, 0x92, 0xac, 0x03, 0xfa],
 ];
 
-/// Determine if this point is of small order by checking against the
-/// eight known torsion points (table lookup, no curve syscalls).
-#[inline(always)]
-fn is_small_order(point: &PodEdwardsPoint) -> bool {
-    EIGHT_TORSION.iter().any(|t| point.0 == *t)
+#[cfg(test)]
+fn is_small_order(point: &[u8; 32]) -> bool {
+    EIGHT_TORSION.iter().any(|t| *t == *point)
 }
 
 #[cfg(test)]
@@ -198,9 +151,7 @@ mod tests {
         // Refer to https://github.com/dalek-cryptography/curve25519-dalek/blob/43a16f03d4c635a8836c23ac07244c116ea3aab8/curve25519-dalek/src/edwards.rs#L1992
 
         // Base point (has large order)
-        let base_point_bytes = G;
-        let base_point = PodEdwardsPoint(base_point_bytes);
-        assert_eq!(is_small_order(&base_point), false);
+        assert_eq!(is_small_order(&G), false);
 
         // Torsion points (have small order)
         for i in 0..8 {
@@ -208,16 +159,17 @@ mod tests {
             let compressed = torsion_point.compress();
             let torsion_point_bytes = compressed.to_bytes();
             assert_eq!(torsion_point_bytes, EIGHT_TORSION[i], "torsion point {i} mismatch");
-            assert_eq!(is_small_order(&PodEdwardsPoint(torsion_point_bytes)), true);
+            assert_eq!(is_small_order(&torsion_point_bytes), true);
         }
     }
 
+
     #[test]
     fn test_hello_world() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
             49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
-        ];
+        ]);
         let sig: [u8; 64] = [
             164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
             28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
@@ -231,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_error_invalid_public_key() {
-        let pubkey = EIGHT_TORSION[0];
+        let pubkey = Address::from(EIGHT_TORSION[0]);
         let sig: [u8; 64] = [
             164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
             28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
@@ -247,10 +199,10 @@ mod tests {
 
     #[test]
     fn test_error_invalid_signature() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
             49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
-        ];
+        ]);
         let sig: [u8; 64] = [
             164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
             28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
@@ -266,10 +218,10 @@ mod tests {
 
     #[test]
     fn test_hello_worldv() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
             49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
-        ];
+        ]);
         let sig: [u8; 64] = [
             164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
             28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33,
@@ -286,11 +238,11 @@ mod tests {
 
     #[test]
     fn test_vector_1() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64,
             0x07, 0x3a, 0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68,
             0xf7, 0x07, 0x51, 0x1a,
-        ];
+        ]);
 
         let sig: [u8; 64] = [
             0xe5, 0x56, 0x43, 0x00, 0xc3, 0x60, 0xac, 0x72, 0x90, 0x86, 0xe2, 0xcc, 0x80, 0x6e,
@@ -306,11 +258,11 @@ mod tests {
 
     #[test]
     fn test_vector_2() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7, 0x4d, 0x1b,
             0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c, 0xc0, 0xcd, 0x55, 0xf1,
             0x2a, 0xf4, 0x66, 0x0c,
-        ];
+        ]);
 
         let sig: [u8; 64] = [
             0x92, 0xa0, 0x09, 0xa9, 0xf0, 0xd4, 0xca, 0xb8, 0x72, 0x0e, 0x82, 0x0b, 0x5f, 0x64,
@@ -326,11 +278,11 @@ mod tests {
 
     #[test]
     fn test_vector_3() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             0xfc, 0x51, 0xcd, 0x8e, 0x62, 0x18, 0xa1, 0xa3, 0x8d, 0xa4, 0x7e, 0xd0, 0x02, 0x30,
             0xf0, 0x58, 0x08, 0x16, 0xed, 0x13, 0xba, 0x33, 0x03, 0xac, 0x5d, 0xeb, 0x91, 0x15,
             0x48, 0x90, 0x80, 0x25,
-        ];
+        ]);
 
         let sig: [u8; 64] = [
             0x62, 0x91, 0xd6, 0x57, 0xde, 0xec, 0x24, 0x02, 0x48, 0x27, 0xe6, 0x9c, 0x3a, 0xbe,
@@ -348,11 +300,11 @@ mod tests {
 
     #[test]
     fn test_prehashed() {
-        let pubkey: [u8; 32] = [
+        let pubkey = Address::from([
             0xfc, 0x51, 0xcd, 0x8e, 0x62, 0x18, 0xa1, 0xa3, 0x8d, 0xa4, 0x7e, 0xd0, 0x02, 0x30,
             0xf0, 0x58, 0x08, 0x16, 0xed, 0x13, 0xba, 0x33, 0x03, 0xac, 0x5d, 0xeb, 0x91, 0x15,
             0x48, 0x90, 0x80, 0x25,
-        ];
+        ]);
 
         let sig: [u8; 64] = [
             0x62, 0x91, 0xd6, 0x57, 0xde, 0xec, 0x24, 0x02, 0x48, 0x27, 0xe6, 0x9c, 0x3a, 0xbe,
@@ -372,18 +324,18 @@ mod tests {
 
     #[test]
     fn test_challenge_hashv() {
-        let sig_r = PodEdwardsPoint([
+        let sig_r: [u8; 32] = [
             164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86,
             28, 108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33,
-        ]);
-        let pubkey = [
+        ];
+        let pubkey = Address::from([
             73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233,
             49, 154, 201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
-        ];
+        ]);
         let messagev: &[&[u8]] = &[b"hello", b" ", b"world"];
 
         let expected =
-            Sha512::hashv(&[sig_r.0.as_ref(), pubkey.as_ref(), b"hello", b" ", b"world"]);
+            Sha512::hashv(&[sig_r.as_ref(), pubkey.as_ref(), b"hello", b" ", b"world"]);
 
         assert_eq!(
             challenge::<Sha512>(&sig_r, &pubkey, messagev),

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -12,30 +12,165 @@
 //! Host builds still use `curve25519-dalek` as the reference implementation so
 //! tests and off-chain callers stay aligned with the Solana path.
 
-#[cfg(not(target_os = "solana"))]
-pub(crate) fn scalar_from_canonical_bytes(bytes: [u8; 32]) -> Option<[u8; 32]> {
-    Option::from(curve25519_dalek::scalar::Scalar::from_canonical_bytes(
-        bytes,
-    ))
-    .map(|scalar: curve25519_dalek::scalar::Scalar| scalar.to_bytes())
-}
-
-#[cfg(not(target_os = "solana"))]
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
 pub(crate) fn scalar_from_bytes_mod_order_wide(input: &[u8; 64]) -> [u8; 32] {
     curve25519_dalek::scalar::Scalar::from_bytes_mod_order_wide(input).to_bytes()
 }
 
-#[cfg(target_os = "solana")]
-pub(crate) fn scalar_from_canonical_bytes(bytes: [u8; 32]) -> Option<[u8; 32]> {
-    raw::scalar_from_canonical_bytes(bytes)
-}
-
-#[cfg(target_os = "solana")]
+#[cfg(any(target_arch = "bpf", target_os = "solana"))]
 pub(crate) fn scalar_from_bytes_mod_order_wide(input: &[u8; 64]) -> [u8; 32] {
-    raw::scalar_from_bytes_mod_order_wide(input)
+    barrett32::scalar_from_bytes_mod_order_wide(input)
 }
 
-#[cfg(any(target_os = "solana", test))]
+#[cfg(any(target_arch = "bpf", target_os = "solana", test))]
+mod barrett32 {
+    /// Ed25519 group order L as 8 × u32 limbs (little-endian).
+    const L: [u32; 8] = [
+        0x5cf5d3ed, 0x5812631a, 0xa2f79cd6, 0x14def9de,
+        0x00000000, 0x00000000, 0x00000000, 0x10000000,
+    ];
+
+    /// Barrett constant μ = floor(2^512 / L) as 9 × u32 limbs (little-endian).
+    const MU: [u32; 9] = [
+        0x0a2c131b, 0xed9ce5a3, 0x086329a7, 0x2106215d,
+        0xffffffeb, 0xffffffff, 0xffffffff, 0xffffffff,
+        0x0000000f,
+    ];
+
+    /// Multiply a 16-limb number by the 9-limb constant MU, returning
+    /// limbs [16..25] of the 25-limb product (i.e. the result >> 512).
+    #[inline(always)]
+    fn mul_x_mu(x: &[u32; 16]) -> [u32; 9] {
+        let mut result = [0u32; 25];
+
+        for i in 0..16 {
+            let mut carry = 0u64;
+            for j in 0..9 {
+                carry += (x[i] as u64) * (MU[j] as u64) + result[i + j] as u64;
+                result[i + j] = carry as u32;
+                carry >>= 32;
+            }
+            let mut k = i + 9;
+            while carry > 0 && k < 25 {
+                carry += result[k] as u64;
+                result[k] = carry as u32;
+                carry >>= 32;
+                k += 1;
+            }
+        }
+
+        [
+            result[16], result[17], result[18], result[19],
+            result[20], result[21], result[22], result[23],
+            result[24],
+        ]
+    }
+
+    /// Multiply a 9-limb quotient estimate by the 8-limb constant L,
+    /// returning the low 9 limbs (mod 2^288).
+    #[inline(always)]
+    fn mul_q_l(q: &[u32; 9]) -> [u32; 9] {
+        let mut result = [0u32; 9];
+
+        for i in 0..9 {
+            let mut carry = 0u64;
+            for j in 0..8 {
+                if i + j >= 9 {
+                    break;
+                }
+                carry += (q[i] as u64) * (L[j] as u64) + result[i + j] as u64;
+                result[i + j] = carry as u32;
+                carry >>= 32;
+            }
+            let mut k = i + 8.min(9 - i);
+            while carry > 0 && k < 9 {
+                carry += result[k] as u64;
+                result[k] = carry as u32;
+                carry >>= 32;
+                k += 1;
+            }
+        }
+
+        result
+    }
+
+    /// Subtract b from a (9-limb), returning result and whether it underflowed.
+    #[inline(always)]
+    fn sub9(a: &[u32; 9], b: &[u32; 9]) -> ([u32; 9], bool) {
+        let mut result = [0u32; 9];
+        let mut borrow = 0u64;
+
+        for i in 0..9 {
+            let diff = (a[i] as u64)
+                .wrapping_sub(b[i] as u64)
+                .wrapping_sub(borrow);
+            result[i] = diff as u32;
+            borrow = (diff >> 63) & 1;
+        }
+
+        (result, borrow != 0)
+    }
+
+    /// Returns true if a >= L (a is 9 limbs, L is 8 limbs).
+    #[inline(always)]
+    fn gte_l(a: &[u32; 9]) -> bool {
+        if a[8] != 0 {
+            return true;
+        }
+        for i in (0..8).rev() {
+            if a[i] > L[i] {
+                return true;
+            }
+            if a[i] < L[i] {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[inline(always)]
+    pub(super) fn scalar_from_bytes_mod_order_wide(input: &[u8; 64]) -> [u8; 32] {
+        // Parse input as 16 × u32 limbs (little-endian).
+        let mut x = [0u32; 16];
+        for i in 0..16 {
+            x[i] = u32::from_le_bytes([
+                input[i * 4],
+                input[i * 4 + 1],
+                input[i * 4 + 2],
+                input[i * 4 + 3],
+            ]);
+        }
+
+        // q_hat = (x * μ) >> 512
+        let q_hat = mul_x_mu(&x);
+
+        // r = x - q_hat * L (mod 2^288, using 9 limbs)
+        let q_l = mul_q_l(&q_hat);
+        let x9 = [x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8]];
+        let (mut r, _) = sub9(&x9, &q_l);
+
+        // At most 2 corrections needed.
+        if gte_l(&r) {
+            let l9 = [L[0], L[1], L[2], L[3], L[4], L[5], L[6], L[7], 0];
+            let (r2, _) = sub9(&r, &l9);
+            r = r2;
+        }
+        if gte_l(&r) {
+            let l9 = [L[0], L[1], L[2], L[3], L[4], L[5], L[6], L[7], 0];
+            let (r2, _) = sub9(&r, &l9);
+            r = r2;
+        }
+
+        // Serialize the low 8 limbs as 32 bytes LE.
+        let mut out = [0u8; 32];
+        for i in 0..8 {
+            out[i * 4..i * 4 + 4].copy_from_slice(&r[i].to_le_bytes());
+        }
+        out
+    }
+}
+
+#[cfg(test)]
 mod raw {
     const L_BYTES: [u8; 32] = [
         0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde,
@@ -43,38 +178,6 @@ mod raw {
         0x00, 0x10,
     ];
 
-    const L: Scalar52 = Scalar52([
-        0x0002631a5cf5d3ed,
-        0x000dea2f79cd6581,
-        0x000000000014def9,
-        0x0000000000000000,
-        0x0000100000000000,
-    ]);
-
-    const LFACTOR: u64 = 0x51da312547e1b;
-
-    const R: Scalar52 = Scalar52([
-        0x000f48bd6721e6ed,
-        0x0003bab5ac67e45a,
-        0x000fffffeb35e51b,
-        0x000fffffffffffff,
-        0x00000fffffffffff,
-    ]);
-
-    const RR: Scalar52 = Scalar52([
-        0x0009d265e952d13b,
-        0x000d63c715bea69f,
-        0x0005be65cb687604,
-        0x0003dceec73d217f,
-        0x000009411b7c309a,
-    ]);
-
-    #[derive(Clone, Copy)]
-    struct Scalar52([u64; 5]);
-
-    const SCALAR52_ZERO: Scalar52 = Scalar52([0, 0, 0, 0, 0]);
-
-    #[inline(always)]
     pub(super) fn scalar_from_canonical_bytes(bytes: [u8; 32]) -> Option<[u8; 32]> {
         if bytes[31] >> 7 != 0 {
             return None;
@@ -91,196 +194,11 @@ mod raw {
 
         None
     }
-
-    #[inline(always)]
-    pub(super) fn scalar_from_bytes_mod_order_wide(input: &[u8; 64]) -> [u8; 32] {
-        Scalar52::from_bytes_wide(input).as_bytes()
-    }
-
-    #[inline(always)]
-    fn m(x: u64, y: u64) -> u128 {
-        (x as u128) * (y as u128)
-    }
-
-    impl core::ops::Index<usize> for Scalar52 {
-        type Output = u64;
-
-        fn index(&self, index: usize) -> &Self::Output {
-            &self.0[index]
-        }
-    }
-
-    impl core::ops::IndexMut<usize> for Scalar52 {
-        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-            &mut self.0[index]
-        }
-    }
-
-    impl Scalar52 {
-        #[inline(always)]
-        fn from_bytes_wide(bytes: &[u8; 64]) -> Scalar52 {
-            let mut words = [0u64; 8];
-            for i in 0..8 {
-                for j in 0..8 {
-                    words[i] |= (bytes[(i * 8) + j] as u64) << (j * 8);
-                }
-            }
-
-            let mask = (1u64 << 52) - 1;
-            let mut lo = SCALAR52_ZERO;
-            let mut hi = SCALAR52_ZERO;
-
-            lo[0] = words[0] & mask;
-            lo[1] = ((words[0] >> 52) | (words[1] << 12)) & mask;
-            lo[2] = ((words[1] >> 40) | (words[2] << 24)) & mask;
-            lo[3] = ((words[2] >> 28) | (words[3] << 36)) & mask;
-            lo[4] = ((words[3] >> 16) | (words[4] << 48)) & mask;
-            hi[0] = (words[4] >> 4) & mask;
-            hi[1] = ((words[4] >> 56) | (words[5] << 8)) & mask;
-            hi[2] = ((words[5] >> 44) | (words[6] << 20)) & mask;
-            hi[3] = ((words[6] >> 32) | (words[7] << 32)) & mask;
-            hi[4] = words[7] >> 20;
-
-            lo = Scalar52::montgomery_mul(&lo, &R);
-            hi = Scalar52::montgomery_mul(&hi, &RR);
-
-            Scalar52::add(&hi, &lo)
-        }
-
-        #[inline(always)]
-        fn as_bytes(&self) -> [u8; 32] {
-            let mut s = [0u8; 32];
-
-            s[0] = (self.0[0] >> 0) as u8;
-            s[1] = (self.0[0] >> 8) as u8;
-            s[2] = (self.0[0] >> 16) as u8;
-            s[3] = (self.0[0] >> 24) as u8;
-            s[4] = (self.0[0] >> 32) as u8;
-            s[5] = (self.0[0] >> 40) as u8;
-            s[6] = ((self.0[0] >> 48) | (self.0[1] << 4)) as u8;
-            s[7] = (self.0[1] >> 4) as u8;
-            s[8] = (self.0[1] >> 12) as u8;
-            s[9] = (self.0[1] >> 20) as u8;
-            s[10] = (self.0[1] >> 28) as u8;
-            s[11] = (self.0[1] >> 36) as u8;
-            s[12] = (self.0[1] >> 44) as u8;
-            s[13] = (self.0[2] >> 0) as u8;
-            s[14] = (self.0[2] >> 8) as u8;
-            s[15] = (self.0[2] >> 16) as u8;
-            s[16] = (self.0[2] >> 24) as u8;
-            s[17] = (self.0[2] >> 32) as u8;
-            s[18] = (self.0[2] >> 40) as u8;
-            s[19] = ((self.0[2] >> 48) | (self.0[3] << 4)) as u8;
-            s[20] = (self.0[3] >> 4) as u8;
-            s[21] = (self.0[3] >> 12) as u8;
-            s[22] = (self.0[3] >> 20) as u8;
-            s[23] = (self.0[3] >> 28) as u8;
-            s[24] = (self.0[3] >> 36) as u8;
-            s[25] = (self.0[3] >> 44) as u8;
-            s[26] = (self.0[4] >> 0) as u8;
-            s[27] = (self.0[4] >> 8) as u8;
-            s[28] = (self.0[4] >> 16) as u8;
-            s[29] = (self.0[4] >> 24) as u8;
-            s[30] = (self.0[4] >> 32) as u8;
-            s[31] = (self.0[4] >> 40) as u8;
-
-            s
-        }
-
-        #[inline(always)]
-        fn add(a: &Scalar52, b: &Scalar52) -> Scalar52 {
-            let mut sum = SCALAR52_ZERO;
-            let mask = (1u64 << 52) - 1;
-            let mut carry = 0u64;
-
-            for i in 0..5 {
-                carry = a[i] + b[i] + (carry >> 52);
-                sum[i] = carry & mask;
-            }
-
-            Scalar52::sub(&sum, &L)
-        }
-
-        #[inline(always)]
-        fn sub(a: &Scalar52, b: &Scalar52) -> Scalar52 {
-            #[inline(always)]
-            fn black_box(value: u64) -> u64 {
-                unsafe { core::ptr::read_volatile(&value) }
-            }
-
-            let mut difference = SCALAR52_ZERO;
-            let mask = (1u64 << 52) - 1;
-            let mut borrow = 0u64;
-
-            for i in 0..5 {
-                borrow = a[i].wrapping_sub(b[i] + (borrow >> 63));
-                difference[i] = borrow & mask;
-            }
-
-            let underflow_mask = ((borrow >> 63) ^ 1).wrapping_sub(1);
-            let mut carry = 0u64;
-            for i in 0..5 {
-                carry = (carry >> 52) + difference[i] + (L[i] & black_box(underflow_mask));
-                difference[i] = carry & mask;
-            }
-
-            difference
-        }
-
-        #[inline(always)]
-        fn mul_internal(a: &Scalar52, b: &Scalar52) -> [u128; 9] {
-            [
-                m(a[0], b[0]),
-                m(a[0], b[1]) + m(a[1], b[0]),
-                m(a[0], b[2]) + m(a[1], b[1]) + m(a[2], b[0]),
-                m(a[0], b[3]) + m(a[1], b[2]) + m(a[2], b[1]) + m(a[3], b[0]),
-                m(a[0], b[4]) + m(a[1], b[3]) + m(a[2], b[2]) + m(a[3], b[1]) + m(a[4], b[0]),
-                m(a[1], b[4]) + m(a[2], b[3]) + m(a[3], b[2]) + m(a[4], b[1]),
-                m(a[2], b[4]) + m(a[3], b[3]) + m(a[4], b[2]),
-                m(a[3], b[4]) + m(a[4], b[3]),
-                m(a[4], b[4]),
-            ]
-        }
-
-        #[inline(always)]
-        fn montgomery_reduce(limbs: &[u128; 9]) -> Scalar52 {
-            #[inline(always)]
-            fn part1(sum: u128) -> (u128, u64) {
-                let p = (sum as u64).wrapping_mul(LFACTOR) & ((1u64 << 52) - 1);
-                ((sum + m(p, L[0])) >> 52, p)
-            }
-
-            #[inline(always)]
-            fn part2(sum: u128) -> (u128, u64) {
-                let w = (sum as u64) & ((1u64 << 52) - 1);
-                (sum >> 52, w)
-            }
-
-            let (carry, n0) = part1(limbs[0]);
-            let (carry, n1) = part1(carry + limbs[1] + m(n0, L[1]));
-            let (carry, n2) = part1(carry + limbs[2] + m(n0, L[2]) + m(n1, L[1]));
-            let (carry, n3) = part1(carry + limbs[3] + m(n1, L[2]) + m(n2, L[1]));
-            let (carry, n4) = part1(carry + limbs[4] + m(n0, L[4]) + m(n2, L[2]) + m(n3, L[1]));
-
-            let (carry, r0) = part2(carry + limbs[5] + m(n1, L[4]) + m(n3, L[2]) + m(n4, L[1]));
-            let (carry, r1) = part2(carry + limbs[6] + m(n2, L[4]) + m(n4, L[2]));
-            let (carry, r2) = part2(carry + limbs[7] + m(n3, L[4]));
-            let (carry, r3) = part2(carry + limbs[8] + m(n4, L[4]));
-            let r4 = carry as u64;
-
-            Scalar52::sub(&Scalar52([r0, r1, r2, r3, r4]), &L)
-        }
-
-        #[inline(always)]
-        fn montgomery_mul(a: &Scalar52, b: &Scalar52) -> Scalar52 {
-            Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b))
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::raw;
+    use super::{raw, barrett32};
     use rand::{RngCore, SeedableRng};
     use rand::rngs::{OsRng, StdRng};
 
@@ -442,7 +360,7 @@ mod tests {
 
         for input in cases {
             let expected = dalek_wide(&input);
-            assert_eq!(raw::scalar_from_bytes_mod_order_wide(&input), expected);
+            assert_eq!(barrett32::scalar_from_bytes_mod_order_wide(&input), expected);
         }
     }
 
@@ -450,7 +368,7 @@ mod tests {
     fn reduce_wide_many() {
         for seed in 0..512u64 {
             let input = generated_bytes::<64>(0xd1b5_4a32_d192_ed03 ^ seed);
-            let reduced = raw::scalar_from_bytes_mod_order_wide(&input);
+            let reduced = barrett32::scalar_from_bytes_mod_order_wide(&input);
             let expected = dalek_wide(&input);
 
             assert_eq!(reduced, expected, "seed {seed} input {input:?}");
@@ -468,7 +386,7 @@ mod tests {
             let mut input = [0u8; 64];
             input[bit / 8] = 1u8 << (bit % 8);
 
-            let reduced = raw::scalar_from_bytes_mod_order_wide(&input);
+            let reduced = barrett32::scalar_from_bytes_mod_order_wide(&input);
             let expected = dalek_wide(&input);
 
             assert_eq!(reduced, expected, "bit {bit} input {input:?}");
@@ -500,10 +418,11 @@ mod tests {
             let mut wide = [0u8; 64];
             rng.fill_bytes(&mut wide);
 
-            let reduced = raw::scalar_from_bytes_mod_order_wide(&wide);
             let expected = dalek_wide(&wide);
 
-            assert_eq!(reduced, expected, "seed {seed:?} case {case} wide {wide:?}");
+            let reduced = barrett32::scalar_from_bytes_mod_order_wide(&wide);
+            assert_eq!(reduced, expected, "seed {seed:?} case {case} barrett32 {wide:?}");
+
             assert_eq!(
                 raw::scalar_from_canonical_bytes(reduced),
                 Some(reduced),

--- a/test-program/Cargo.lock
+++ b/test-program/Cargo.lock
@@ -502,7 +502,7 @@ version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "sha2 0.10.9",
- "solana-define-syscall 2.3.0",
+ "solana-address 2.6.0",
  "solana-program-error",
 ]
 
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "five8_core"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
+checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
 name = "fnv"
@@ -1473,7 +1473,7 @@ checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -1901,7 +1901,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -1961,7 +1961,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -2047,12 +2047,6 @@ dependencies = [
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
-
-[[package]]
-name = "solana-define-syscall"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
@@ -2065,9 +2059,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-epoch-rewards"
@@ -2148,7 +2142,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
 ]
@@ -2173,7 +2167,7 @@ checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
 ]
 
@@ -2282,7 +2276,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]
@@ -2497,7 +2491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
 dependencies = [
  "k256",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 

--- a/test-program/src/lib.rs
+++ b/test-program/src/lib.rs
@@ -1,51 +1,48 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(unexpected_cfgs)]
 
-use brine_ed25519::{verify, hasher::Sha512};
+use brine_ed25519::{hasher::Sha512, verify, Address};
 use pinocchio::{
-    default_allocator, nostd_panic_handler, program_entrypoint, 
-    AccountView, Address, ProgramResult,
+    default_allocator, nostd_panic_handler
 };
 
-const HELLO_WORLD_PUBKEY: [u8; 32] = [
+const HELLO_WORLD_PUBKEY: Address = Address::new_from_array([
     73, 73, 170, 112, 75, 235, 154, 81, 203, 8, 44, 245, 233, 18, 204, 136, 162, 9, 233, 49, 154,
     201, 171, 175, 47, 6, 223, 101, 105, 80, 95, 166,
-];
+]);
 
 const HELLO_WORLD_SIG: [u8; 64] = [
     164, 121, 89, 242, 88, 29, 80, 177, 104, 20, 102, 176, 48, 133, 68, 8, 105, 33, 58, 86, 28,
     108, 198, 140, 160, 219, 62, 184, 154, 181, 140, 33, 35, 102, 183, 203, 111, 33, 55, 170, 180,
-    138, 92, 196, 185, 201, 122, 167, 15, 112, 9, 228, 226, 112, 111, 10, 142, 73, 85, 43, 81,
-    152, 204, 13,
+    138, 92, 196, 185, 201, 122, 167, 15, 112, 9, 228, 226, 112, 111, 10, 142, 73, 85, 43, 81, 152,
+    204, 13,
 ];
 
 default_allocator!();
 nostd_panic_handler!();
-program_entrypoint!(process_instruction);
 
-fn process_instruction(
-    _program_id: &Address,
-    _accounts: &mut [AccountView],
-    _instruction_data: &[u8],
-) -> ProgramResult {
-    verify::<Sha512>(&HELLO_WORLD_PUBKEY, &HELLO_WORLD_SIG, &[b"hello world"])
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn entrypoint() -> u64 {
+    match verify::<Sha512>(&HELLO_WORLD_PUBKEY, &HELLO_WORLD_SIG, &[b"hello world"]) {
+        Ok(_) => 0,
+        Err(e) => e.into()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use mollusk_svm::{Mollusk, result::ProgramResult};
+    use mollusk_svm::{Mollusk, result::Check};
     use solana_instruction::Instruction;
 
     #[test]
     fn test_verify() {
-        let mollusk = Mollusk::new( &[0x02;32].into(), "target/deploy/brine_ed25519_test");
+        let mollusk = Mollusk::new(&[0x02; 32].into(), "target/deploy/brine_ed25519_test");
 
-        let result = mollusk.process_instruction(
-            &Instruction::new_with_bytes([0x02;32].into(), &[], vec![]),
+        let result = mollusk.process_and_validate_instruction(
+            &Instruction::new_with_bytes([0x02; 32].into(), &[], vec![]),
             &[],
+            &[Check::success()]
         );
-
         println!("verify consumed {} CUs", result.compute_units_consumed);
-        assert!(matches!(result.program_result, ProgramResult::Success), "{result:?}");
     }
 }


### PR DESCRIPTION
Drastically reduces CUs with 3 major optimizations:

- replaces the existing mul > mul > sub pattern by negating `G` and simplifying the algorithm into a single multiscalar multiplication
- replaces expensive 128-bit Montgomery reduction with platform-specific 32-bit Barrett reduction
- removes redundant scalar and point verifications with a `SAFETY` comment linking to where they are performed in the runtime by the msm syscall

This now drives compute down so much that it becomes cheaper in lamports, data *and* CUs to use the ed25519 multiscalar multiplication syscall instead of the ed25519 precompile.